### PR TITLE
Added support for configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ To launch the app:
 
 - ```node . -- input (-i)```
 
+- ```node . -- config (-c)```
+
 ## Example
 (Start from the main directory)
 
@@ -49,6 +51,18 @@ To launch the app:
 - Generates markdown file to html file
 
     example: ```node . --input /SherlocksStories/testmd.md```
+
+- Support for configuration files
+
+## Configuration file
+Configuration file should contain the following attributes: *input*, *stylesheet*
+
+```
+{
+    "input":"SherlocksStories/testmd.md",
+    "stylesheet": "https://cdnjs.cloudflare.com/ajax/libs/tufte-css/1.8.0/tufte.min.css"
+}
+```
 
 # Authors
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,0 +1,1 @@
+<hr><br><h1 style='text-align:center;'><em>List of Stories</em></h1><p style='text-align:center;'>(Sherlock Holmes)</p><hr> <h3 style='text-align:center; text-decoration: none'><a href=" /Users/bork/Desktop/Seneca/5TH SEMESTER/OSD/lab4/qck-ssg-final/dist/testmd.html">testmd</a></h3><br>

--- a/dist/testmd.html
+++ b/dist/testmd.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>	undefined</title>
+    <link rel="stylesheet" type="text/css" href="undefined" />
+</head>
+<body style="background-color: #E0D2C3;">
+    <a href="javascript:history.back()">Go Back</a>
+    <em>	<h1 style='text-align:center;'>undefined</h1></em>
+       <hr>
+  <strong> <em> <p style='text-align:center;' >
+<h1>This is h1 tag</h1>
+<h2>This is h2 tag</h2><br><i>This should be italic</i><br><b>This is bold</b><br><code>This is code</code>
+<hr></p></em></strong>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ import boxen from "boxen";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import prettier from "prettier";
+import { exit } from "process";
 
 const dir = "dist";
 
@@ -30,15 +31,44 @@ setTimeout(function () {
     .option("i", {
       alias: "input",
       describe: "File name",
-      type: "string",
-      demandOption: true,
+      type: "string"
+    })
+    .option("c", {
+      alias: "config",
+      describe: "Configuration file", 
+      type: "string"
     })
     .version("v", "version", "qck-ssg v0.1.2")
     .alias("v", "version")
     .alias("s", "stylesheet").argv;
+  
 
-  let filename = `${options.input}`;
-  let style = `${options.stylesheet}`;
+  let filename = options.input;
+  let style = options.stylesheet;
+  let config_path = options.config;
+
+  // Check if there is a config argument
+  if(config_path) {
+    const config_file = fs.readFileSync(config_path)
+    const parsed = JSON.parse(config_file)
+    // Check if there is a filename in config file
+    if (parsed.input) {
+        if (parsed.stylesheet) {
+          style = parsed.stylesheet
+        } else {
+          style = ""
+        }
+        filename = parsed.input
+    } else {
+      console.log("Missing input path to a file or directory in config file")
+      exit()
+    }
+  } else {
+    if(!filename) {
+      console.log("Missing input path to a file or directory")
+      exit()
+    }
+  }
 
   const readFile = (filename) => {
     const rawFile = fs.readFileSync(filename, "utf8");


### PR DESCRIPTION
Hi! 

I have added support for configuration files. 

1. `-c` or `--config` flags accept a file path to a JSON config file.
2. If the file is missing, or can't be parsed as JSON, tool exits with an appropriate error message
3. If the `-c` or `--config` option is provided, tool ignores all other options (i.e., a config file overrides other options on the command line).
4. The tool ignores any options in the config file it doesn't recognize.

Examples of config files
```
{
    "input":"SherlocksStories/testmd.md",
    "some_future_feature": "testing"
}
```

```
{
    "input":"SherlocksStories/testmd.md",
    "stylesheet": "https://cdnjs.cloudflare.com/ajax/libs/tufte-css/1.8.0/tufte.min.css"
}
```

```
{}
```